### PR TITLE
golbd: use bufio.Scanner to extract lines

### DIFF
--- a/lbcluster/lbcluster.go
+++ b/lbcluster/lbcluster.go
@@ -247,10 +247,9 @@ func (self *LBCluster) apply_metric() {
 	return
 }
 
-
 /* The following functions are for the roger state and its timeout
 
-*/
+ */
 func NewTimeoutClient(connectTimeout time.Duration, readWriteTimeout time.Duration) *http.Client {
 
 	return &http.Client{
@@ -270,7 +269,6 @@ func timeoutDialer(cTimeout time.Duration, rwTimeout time.Duration) func(net, ad
 		return conn, nil
 	}
 }
-
 
 func (self *LBCluster) checkRogerState(host string) string {
 
@@ -305,5 +303,3 @@ func (self *LBCluster) checkRogerState(host string) string {
 	return logmessage
 
 }
-
-

--- a/lbcluster/lbcluster_snmp.go
+++ b/lbcluster/lbcluster_snmp.go
@@ -2,13 +2,12 @@ package lbcluster
 
 import (
 	"fmt"
-	//"github.com/k-sone/snmpgo"
-	"github.com/reguero/go-snmplib"
 	"net"
 	"regexp"
 	"strconv"
-	//"strings"
 	"time"
+
+	"github.com/reguero/go-snmplib"
 )
 
 //This one has only internal methods. They should not be called from outside the lbcluster
@@ -52,7 +51,7 @@ func (self *LBCluster) snmp_req(host string, result chan<- RetSnmp) {
 		time.Duration(TIMEOUT)*time.Second, 2)
 	if err != nil {
 		// Failed to create snmpgo.SNMP object
-		result <- RetSnmp{metric, host, fmt.Sprint("contacted node: %v error creating the snmp object: %v", host, err)}
+		result <- RetSnmp{metric, host, fmt.Sprintf("contacted node: %v error creating the snmp object: %v", host, err)}
 		return
 	}
 	defer snmp.Close()

--- a/lbcluster/lbcluster_snmp.go
+++ b/lbcluster/lbcluster_snmp.go
@@ -77,23 +77,22 @@ func (self *LBCluster) snmp_req(host string, result chan<- RetSnmp) {
 		return
 	}
 
-
 	logmessage := fmt.Sprintf("contacted node: %v transport: %v - reply was %v", host, transport, pdu)
 
 	var pduInteger int
 	switch t := pdu.(type) {
-    case int:
+	case int:
 		pduInteger = pdu.(int)
-    case string:
+	case string:
 		re := regexp.MustCompile(self.Cluster_name + "=([0-9]+)")
 		submatch := re.FindStringSubmatch(pdu.(string))
 		if submatch != nil {
 			pduInteger, err = strconv.Atoi(submatch[1])
 		}
-    default:
-        result <- RetSnmp{metric, host, fmt.Sprintf("The node returned an unexpected type %s in %v", t, pdu)}
-        return	   
-    }
+	default:
+		result <- RetSnmp{metric, host, fmt.Sprintf("The node returned an unexpected type %s in %v", t, pdu)}
+		return
+	}
 	result <- RetSnmp{pduInteger, host, logmessage}
 	return
 

--- a/lbd.go
+++ b/lbd.go
@@ -99,12 +99,12 @@ func loadClusters(config *Config, lg *lbcluster.Log) []lbcluster.LBCluster {
 }
 
 func loadConfig(configFile string, lg *lbcluster.Log) (*Config, error) {
-	var config Config
-	var p lbcluster.Params
-	var mc map[string][]string
-	mc = make(map[string][]string)
-	var mp map[string]lbcluster.Params
-	mp = make(map[string]lbcluster.Params)
+	var (
+		config Config
+		p      lbcluster.Params
+		mc     = make(map[string][]string)
+		mp     = make(map[string]lbcluster.Params)
+	)
 
 	lines, err := readLines(configFile)
 	if err != nil {

--- a/lbd.go
+++ b/lbd.go
@@ -79,9 +79,9 @@ func loadClusters(config *Config, lg *lbcluster.Log) []lbcluster.LBCluster {
 				Current_best_hosts:      []string{"unknown"},
 				Previous_best_hosts:     []string{"unknown"},
 				Previous_best_hosts_dns: []string{"unknown"},
-				Slog:                 lg,
-				Statistics_filename:  logfilePath + "/golbstatistics." + k,
-				Per_cluster_filename: logfilePath + "/cluster/" + k + ".log"}
+				Slog:                    lg,
+				Statistics_filename:     logfilePath + "/golbstatistics." + k,
+				Per_cluster_filename:    logfilePath + "/cluster/" + k + ".log"}
 			hm = make(map[string]int)
 			for _, h := range v {
 				hm[h] = lbcluster.WorstValue + 1

--- a/lbd_snmp_example_test.go
+++ b/lbd_snmp_example_test.go
@@ -1,16 +1,18 @@
-package main
+package main_test
 
 import (
 	"fmt"
-	"github.com/reguero/go-snmplib"
+	"log"
 	"time"
+
+	snmplib "github.com/reguero/go-snmplib"
 )
 
-func exampleMain() {
-	fmt.Printf("HELLO WORLD")
+func Example() {
+	fmt.Printf("HELLO WORLD\n")
 	oidstr := ".1.3.6.1.4.1.96.255.1"
 	oid := snmplib.MustParseOid(oidstr)
-	fmt.Printf("Got the oid %v", oid)
+	fmt.Printf("Got the oid %v\n", oid)
 
 	target := "ermis12.cern.ch"
 	username := "loadbalancing"
@@ -21,22 +23,21 @@ func exampleMain() {
 
 	wsnmp, err := snmplib.NewSNMPv3(target, username, authAlg, authKey, privAlg, privKey, 2*time.Second, 2)
 	if err != nil {
-		fmt.Printf("Error creating wsnmp => %v\n%v", wsnmp, err)
-
-		return
+		log.Fatalf("Error creating wsnmp => %v\n%v\n", wsnmp, err)
 	}
 	defer wsnmp.Close()
+
 	err = wsnmp.Discover()
 	if err != nil {
-		fmt.Printf("Error in the discover")
+		log.Fatalf("Could not discover: %v", err)
 		return
 	}
 	fmt.Printf("Ready to do the get\n")
 
 	val, err := wsnmp.GetV3(oid)
 
-	fmt.Printf("Got the val %v", val)
-	fmt.Printf("And the error %v", err)
+	fmt.Printf("Got the val %v\n", val)
+	fmt.Printf("And the error %v\n", err)
 
-	fmt.Printf("CALL DONE")
+	fmt.Printf("CALL DONE\n")
 }

--- a/loadClusters_test.go
+++ b/loadClusters_test.go
@@ -18,12 +18,12 @@ func TestLoadClusters(t *testing.T) {
 		TsigExternalKey: "yyy123==",
 		SnmpPassword:    "zzz123",
 		DnsManager:      "111.111.0.111",
-		Clusters:        map[string][]string{"test01.cern.ch": []string{"lxplus142.cern.ch", "lxplus177.cern.ch"}, "test02.cern.ch": []string{"lxplus013.cern.ch", "lxplus038.cern.ch", "lxplus025.cern.ch"}},
-		Parameters: map[string]lbcluster.Params{"test01.cern.ch": lbcluster.Params{Behaviour: "mindless", Best_hosts: 2,
+		Clusters:        map[string][]string{"test01.cern.ch": {"lxplus142.cern.ch", "lxplus177.cern.ch"}, "test02.cern.ch": {"lxplus013.cern.ch", "lxplus038.cern.ch", "lxplus025.cern.ch"}},
+		Parameters: map[string]lbcluster.Params{"test01.cern.ch": {Behaviour: "mindless", Best_hosts: 2,
 			External: true, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"},
-			"test02.cern.ch": lbcluster.Params{Behaviour: "mindless", Best_hosts: 10, External: false, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"}}}
+			"test02.cern.ch": {Behaviour: "mindless", Best_hosts: 10, External: false, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"}}}
 	expected := []lbcluster.LBCluster{
-		lbcluster.LBCluster{Cluster_name: "test01.cern.ch",
+		{Cluster_name: "test01.cern.ch",
 			Loadbalancing_username: "loadbalancing",
 			Loadbalancing_password: "zzz123",
 			Host_metric_table:      map[string]int{"lxplus142.cern.ch": 100000, "lxplus177.cern.ch": 100000},
@@ -36,7 +36,7 @@ func TestLoadClusters(t *testing.T) {
 			Per_cluster_filename:    "./cluster/test01.cern.ch.log",
 			Slog:                    &lg,
 			Current_index:           0},
-		lbcluster.LBCluster{Cluster_name: "test02.cern.ch",
+		{Cluster_name: "test02.cern.ch",
 			Loadbalancing_username: "loadbalancing",
 			Loadbalancing_password: "zzz123",
 			Host_metric_table:      map[string]int{"lxplus013.cern.ch": 100000, "lxplus038.cern.ch": 100000, "lxplus025.cern.ch": 100000},

--- a/loadConfig_test.go
+++ b/loadConfig_test.go
@@ -63,10 +63,10 @@ clusters test02.cern.ch = lxplus013.cern.ch lxplus038.cern.ch lxplus025.cern.ch
 		TsigExternalKey: "yyy123==",
 		SnmpPassword:    "zzz123",
 		DnsManager:      "111.111.0.111",
-		Clusters: map[string][]string{"test01.cern.ch": []string{"lxplus142.cern.ch", "lxplus177.cern.ch"},
-			"test02.cern.ch": []string{"lxplus013.cern.ch", "lxplus038.cern.ch", "lxplus025.cern.ch"}},
-		Parameters: map[string]lbcluster.Params{"test01.cern.ch": lbcluster.Params{Behaviour: "mindless", Best_hosts: 2, External: true, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"},
-			"test02.cern.ch": lbcluster.Params{Behaviour: "mindless", Best_hosts: 10, External: false, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"}}}
+		Clusters: map[string][]string{"test01.cern.ch": {"lxplus142.cern.ch", "lxplus177.cern.ch"},
+			"test02.cern.ch": {"lxplus013.cern.ch", "lxplus038.cern.ch", "lxplus025.cern.ch"}},
+		Parameters: map[string]lbcluster.Params{"test01.cern.ch": {Behaviour: "mindless", Best_hosts: 2, External: true, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"},
+			"test02.cern.ch": {Behaviour: "mindless", Best_hosts: 10, External: false, Metric: "cmsfrontier", Polling_interval: 6, Statistics: "long"}}}
 
 	config, e := loadConfig(f.Name(), &lg)
 	if e != nil {


### PR DESCRIPTION
This CL applies `gofmt -s -w` and `goimport` on the top-level Go files as well as some Go-related good practices.

Also, it introduces the use of `bufio.Scanner` to extract lines from an `io.Reader`.