### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/golbd
+/golbd.exe


### PR DESCRIPTION
1. Fix typo in the name of the `.gitignore` file.
2. Add `golbd` binary to `.gitignore`.