### PR TITLE
[gohack] Fix Go Vet Lock Copy Value Errors

### DIFF
--- a/lbcluster/lbcluster_log.go
+++ b/lbcluster/lbcluster_log.go
@@ -15,7 +15,18 @@ type Log struct {
 	Stdout       bool
 	Debugflag    bool
 	TofilePath   string
-	logMu        sync.Mutex
+	logMu        *sync.Mutex
+}
+
+//NewLog initializes Log struct
+func NewLog(syslogWriter *syslog.Writer, stdout, debugFlag bool, ToFilePath string) Log {
+	return Log{
+		SyslogWriter: syslogWriter,
+		Stdout:       stdout,
+		Debugflag:    debugFlag,
+		TofilePath:   ToFilePath,
+		logMu:        &sync.Mutex{},
+	}
 }
 
 //Logger struct for the Logger interface

--- a/lbd.go
+++ b/lbd.go
@@ -156,7 +156,6 @@ func sleep(seconds time.Duration, chanModified chan int) error {
 		chanModified <- 2
 		time.Sleep(seconds * time.Second)
 	}
-	return nil
 }
 
 func main() {
@@ -171,7 +170,7 @@ func main() {
 	if e != nil {
 		fmt.Printf("Error getting a syslog instance %v\nThe service will only write to the logfile %v\n\n", e, *logFileFlag)
 	}
-	lg := lbcluster.Log{SyslogWriter: log, Stdout: *stdoutFlag, Debugflag: *debugFlag, TofilePath: *logFileFlag}
+	lg := lbcluster.NewLog(log, *stdoutFlag, *debugFlag, *logFileFlag)
 
 	lg.Info("Starting lbd")
 
@@ -203,8 +202,6 @@ func main() {
 			lg.Error("Got an unexpected value")
 		}
 	}
-	lg.Error("The lbd is not supposed to stop")
-
 }
 func checkAliases(config *lbconfig.Config, lg lbcluster.Log, lbclusters []lbcluster.LBCluster) {
 	hostname, e := os.Hostname()

--- a/tests/get_list_hosts_test.go
+++ b/tests/get_list_hosts_test.go
@@ -58,7 +58,7 @@ func TestGetListHostsOne(t *testing.T) {
 }
 
 func TestGetListHostsTwo(t *testing.T) {
-	lg := lbcluster.Log{Stdout: true, Debugflag: false}
+	lg := lbcluster.NewLog(nil, true, false, "")
 
 	clusters := []lbcluster.LBCluster{
 		{Cluster_name: "test01.cern.ch",

--- a/tests/get_state_dns_test.go
+++ b/tests/get_state_dns_test.go
@@ -80,7 +80,7 @@ func TestRefreshDNS(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.cluster_name, func(t *testing.T) {
-			lg := lbcluster.Log{SyslogWriter: nil, Stdout: false, Debugflag: false}
+			lg := lbcluster.NewLog(nil, false, false, "")
 			cluster := lbcluster.LBCluster{
 				Cluster_name:          tc.cluster_name,
 				Current_best_ips:      tc.current_best_ips,

--- a/tests/loadClusters_test.go
+++ b/tests/loadClusters_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func getTestCluster(name string) lbcluster.LBCluster {
-	lg := lbcluster.Log{SyslogWriter: nil, Stdout: true, Debugflag: false}
+	lg := lbcluster.NewLog(nil, true, false, "")
 	return lbcluster.LBCluster{Cluster_name: name,
 		Loadbalancing_username: "loadbalancing",
 		Loadbalancing_password: "zzz123",
@@ -30,7 +30,7 @@ func getTestCluster(name string) lbcluster.LBCluster {
 }
 
 func getSecondTestCluster() lbcluster.LBCluster {
-	lg := lbcluster.Log{SyslogWriter: nil, Stdout: true, Debugflag: false}
+	lg := lbcluster.NewLog(nil, true, false, "")
 	return lbcluster.LBCluster{Cluster_name: "test02.test.cern.ch",
 		Loadbalancing_username: "loadbalancing",
 		Loadbalancing_password: "zzz123",
@@ -164,7 +164,7 @@ func getHost(hostname string, responseInt int, responseString string) lbhost.LBH
 
 }
 func TestLoadClusters(t *testing.T) {
-	lg := lbcluster.Log{SyslogWriter: nil, Stdout: true, Debugflag: false}
+	lg := lbcluster.NewLog(nil, true, false, "")
 
 	config := lbconfig.Config{Master: "lbdxyz.cern.ch",
 		HeartbeatFile: "heartbeat",

--- a/tests/loadConfig_test.go
+++ b/tests/loadConfig_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	lg := lbcluster.Log{Stdout: true, Debugflag: false}
+	lg := lbcluster.NewLog(nil, true, false, "")
 
 	testFiles := []string{"testloadconfig.yaml", "testloadconfig"}
 


### PR DESCRIPTION
The PR fixes the following warnings reported by `go vet ./...`

```
# lb-experts/golbd
./lbd.go:201:25: call of checkAliases copies lock value: gitlab.cern.ch/lb-experts/golbd/lbcluster.Log contains sync.Mutex
./lbd.go:209:47: checkAliases passes lock by value: gitlab.cern.ch/lb-experts/golbd/lbcluster.Log contains sync.Mutex
./lbd.go:233:10: range var hostValue copies lock: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
./lbd.go:237:6: call of func(myHost lbhost.LBHost) {
	myHost.Snmp_req()
	myChannel <- myHost
} copies lock value: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
./lbd.go:234:19: func passes lock by value: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
./lbd.go:241:17: assignment copies lock value to myNewHost: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
./lbd.go:242:40: assignment copies lock value to hostsToCheck[myNewHost.Host_name]: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
./lbd.go:159:2: unreachable code
./lbd.go:206:2: unreachable code
# lb-experts/golbd/lbcluster
lbcluster/lbcluster.go:112:24: assignment copies lock value to current_list[host]: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
lbcluster/lbcluster.go:294:11: assignment copies lock value to host: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex
lbcluster/lbcluster.go:308:11: assignment copies lock value to host: gitlab.cern.ch/lb-experts/golbd/lbhost.LBHost contains sync.Mutex

```