### PR TITLE
go.mod: missing 'go mod tidy'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/reguero/go-snmplib v0.0.0-20181019092238-e566f5619b55
 	gitlab.cern.ch/lb-experts/golbd v0.2.9
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect


### PR DESCRIPTION
Commit 6bf89fed04230b012f0ec63613447de8fb65f33b (see #6) did not apply "go mod tidy" (using a recent version of Go) before commit.

Cc: @DylanGraham 