### PR TITLE
chore: Add make test to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /golbd
 /golbd.exe
+
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ rpm: srpm
 
 clean:
 	rm -rf build vendor
+
+test:
+	go test ./... --cover

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/reguero/go-snmplib v0.0.0-20181019092238-e566f5619b55
 	gitlab.cern.ch/lb-experts/golbd v0.2.9
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect


### PR DESCRIPTION
## Description

Add a `make test` to launch the tests easily. 

## Test

```bash
❯ make test
go test ./... --cover
?       lb-experts/golbd        [no test files]
?       lb-experts/golbd/lbcluster      [no test files]
?       lb-experts/golbd/lbconfig       [no test files]
?       lb-experts/golbd/lbhost [no test files]
ok      lb-experts/golbd/tests  (cached)        coverage: [no statements]
```